### PR TITLE
chore: Update to support 0.19

### DIFF
--- a/src/query.ts
+++ b/src/query.ts
@@ -47,7 +47,7 @@ export function useQuery<
   )
 
   watch(ttl, (ttl) => {
-    toValue(query).updateTTL(ttl)
+    toValue(view)?.updateTTL(ttl)
   })
 
   if (getCurrentInstance()) {

--- a/src/view.test.ts
+++ b/src/view.test.ts
@@ -1254,6 +1254,7 @@ describe('vueView', () => {
         { singular: false, relationships: {} },
         () => {},
         queryCompleteResolver.promise,
+        () => {},
       )
     })
 


### PR DESCRIPTION
0.19 removes updateTTL from Query. Instead it gets passed into the view factory function.

This PR supports both 0.18 and 0.19 by checking the arguments passed to the view factory function. If updateTTL is passed, it is passed to the view. If not, it is taken from the query.

Once 0.18 is old enough the workaround can be removed.