### PR TITLE
Update @rocicorp/zero version from ^1.3.0 to ~1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "vue": "^3.5.13"
   },
   "dependencies": {
-    "@rocicorp/zero": "^1.3.0"
+    "@rocicorp/zero": "~1.3.0"
   },
   "devDependencies": {
     "@antfu/eslint-config": "latest",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ importers:
   .:
     dependencies:
       '@rocicorp/zero':
-        specifier: ^1.3.0
+        specifier: ~1.3.0
         version: 1.3.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))
     devDependencies:
       '@antfu/eslint-config':


### PR DESCRIPTION
Before releasing for the v1, zero needs to be pinned to `v1.3.x` because newer versions would break