### PR TITLE
chore: migrate to pnpm v11

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "zero-vue",
   "type": "module",
   "version": "0.8.0",
-  "packageManager": "pnpm@10.30.3",
+  "packageManager": "pnpm@11.1.2",
   "description": "",
   "license": "MIT",
   "repository": "danielroe/zero-vue",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,12 +10,11 @@ packages:
 
 overrides:
   zero-vue: 'link:.'
-ignoredBuiltDependencies:
-  - esbuild
-  - protobufjs
-  - unrs-resolver
 
-onlyBuiltDependencies:
-  - '@rocicorp/zero-sqlite3'
-  - oxc-resolver
-  - simple-git-hooks
+allowBuilds:
+  '@rocicorp/zero-sqlite3': true
+  esbuild: false
+  oxc-resolver: true
+  protobufjs: false
+  simple-git-hooks: true
+  unrs-resolver: false


### PR DESCRIPTION
### 📚 Description

this migrates us to pnpm v11, and - in particular - to moving to `allowBuilds`